### PR TITLE
Crashes fixed (only village info now)

### DIFF
--- a/src/main/java/jiraiyah/villageinfo/VillageInfo.java
+++ b/src/main/java/jiraiyah/villageinfo/VillageInfo.java
@@ -27,23 +27,23 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
-@Mod(modid = Reference.MOD_ID, version = Reference.VERSION, dependencies = Reference.DEPENDENCIES, name = Reference.MOD_NAME)
+@Mod(modid = Reference.MOD_ID, version = Reference.VERSION, name = Reference.MOD_NAME)
 public class VillageInfo
 {
     @SidedProxy(clientSide = Reference.CLIENT_PROXY, serverSide = Reference.COMMON_PROXY)
     public static CommonProxy PROXY;
 
-    public static boolean solidDraw;
-    public static boolean villageBorder;
-    public static boolean showVillages;
-    public static boolean villageDoors = true;
-    public static boolean villageSphere;
-    public static boolean villageGolem = true;
-    public static boolean villageInfoText;
-    public static boolean villageCenter = true;
-    public static boolean disableDepth = true;
-    public static boolean perVillageColor;
-    public static boolean chunkBorder;
+    public static boolean solidDraw = false;
+    public static boolean villageBorder = false;
+    public static boolean showVillages = false;
+    public static boolean villageDoors = false;
+    public static boolean villageSphere = false;
+    public static boolean villageGolem = false;
+    public static boolean villageInfoText = true;
+    public static boolean villageCenter = false;
+    public static boolean disableDepth = false;
+    public static boolean perVillageColor = false;
+    public static boolean chunkBorder = false;
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)

--- a/src/main/java/jiraiyah/villageinfo/events/VillageDataHandler.java
+++ b/src/main/java/jiraiyah/villageinfo/events/VillageDataHandler.java
@@ -19,6 +19,7 @@ package jiraiyah.villageinfo.events;
 
 import jiraiyah.villageinfo.VillageInfo;
 import jiraiyah.villageinfo.infrastructure.VillageData;
+import jiraiyah.villageinfo.utilities.Log;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.FontRenderer;

--- a/src/main/java/jiraiyah/villageinfo/events/WorldDataCollector.java
+++ b/src/main/java/jiraiyah/villageinfo/events/WorldDataCollector.java
@@ -21,6 +21,7 @@ import jiraiyah.villageinfo.infrastructure.Config;
 import jiraiyah.villageinfo.infrastructure.VillageData;
 import jiraiyah.villageinfo.network.SpawnServerMessage;
 import jiraiyah.villageinfo.network.VillageServerMessage;
+import jiraiyah.villageinfo.utilities.Log;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.village.Village;
@@ -128,6 +129,7 @@ public class WorldDataCollector
 
 	private void resetVillageDataList()
 	{
+		//Log.info("=================> resetVillageDataList");
 		World world = FMLCommonHandler.instance().getMinecraftServerInstance().getEntityWorld();
 		VillageCollection villageCollection = world.getVillageCollection();
 		List<Village> allVillages = villageCollection.getVillageList();

--- a/src/main/java/jiraiyah/villageinfo/inits/ClientEventRegister.java
+++ b/src/main/java/jiraiyah/villageinfo/inits/ClientEventRegister.java
@@ -21,12 +21,14 @@ import jiraiyah.villageinfo.events.ChunkDataHandler;
 import jiraiyah.villageinfo.events.KeyBindingHandler;
 import jiraiyah.villageinfo.events.VillageDataHandler;
 import jiraiyah.villageinfo.events.WorldSpawnHandler;
+import jiraiyah.villageinfo.utilities.Log;
 import net.minecraftforge.common.MinecraftForge;
 
 public class ClientEventRegister
 {
 	public static void register()
 	{
+		//Log.info("=========================================================> Registering Client Events");
 		MinecraftForge.EVENT_BUS.register(new VillageDataHandler());
 		MinecraftForge.EVENT_BUS.register(new WorldSpawnHandler());
 		MinecraftForge.EVENT_BUS.register(new KeyBindingHandler());

--- a/src/main/java/jiraiyah/villageinfo/inits/CommonEventRegister.java
+++ b/src/main/java/jiraiyah/villageinfo/inits/CommonEventRegister.java
@@ -18,6 +18,7 @@
 package jiraiyah.villageinfo.inits;
 
 import jiraiyah.villageinfo.events.WorldDataCollector;
+import jiraiyah.villageinfo.utilities.Log;
 import net.minecraftforge.common.MinecraftForge;
 
 public class CommonEventRegister

--- a/src/main/java/jiraiyah/villageinfo/inits/KeyBindings.java
+++ b/src/main/java/jiraiyah/villageinfo/inits/KeyBindings.java
@@ -18,6 +18,7 @@
 package jiraiyah.villageinfo.inits;
 
 import jiraiyah.villageinfo.references.Reference;
+import jiraiyah.villageinfo.utilities.Log;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.client.settings.KeyModifier;

--- a/src/main/java/jiraiyah/villageinfo/inits/NetworkMessages.java
+++ b/src/main/java/jiraiyah/villageinfo/inits/NetworkMessages.java
@@ -22,6 +22,7 @@ import jiraiyah.villageinfo.network.SpawnServerMessage;
 import jiraiyah.villageinfo.network.VillagePlayerMessage;
 import jiraiyah.villageinfo.network.VillageServerMessage;
 import jiraiyah.villageinfo.references.Reference;
+import jiraiyah.villageinfo.utilities.Log;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import net.minecraftforge.fml.relauncher.Side;
 

--- a/src/main/java/jiraiyah/villageinfo/network/VillagePlayerMessage.java
+++ b/src/main/java/jiraiyah/villageinfo/network/VillagePlayerMessage.java
@@ -18,6 +18,7 @@
 package jiraiyah.villageinfo.network;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.network.PacketBuffer;
 import jiraiyah.villageinfo.events.WorldDataCollector;
 import jiraiyah.villageinfo.inits.NetworkMessages;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
@@ -64,20 +65,16 @@ public class VillagePlayerMessage implements IMessageHandler<VillagePlayerMessag
 		public void fromBytes(ByteBuf buf)
 		{
 			adding = buf.readBoolean();
-			int size = buf.readInt();
-			byte[] bytes = buf.readBytes(size).array();
-			String id = new String(bytes);
-			playerId = UUID.fromString(id);
+			PacketBuffer pbuf = new PacketBuffer(buf);
+			playerId = pbuf.readUniqueId();
 		}
 
 		@Override
 		public void toBytes(ByteBuf buf)
 		{
 			buf.writeBoolean(adding);
-			String id = playerId.toString();
-			byte[] bytes = id.getBytes();
-			buf.writeInt(bytes.length);
-			buf.writeBytes(bytes);
+			PacketBuffer pbuf = new PacketBuffer(buf);
+			pbuf.writeUniqueId(playerId);
 		}
 	}
 }

--- a/src/main/java/jiraiyah/villageinfo/proxies/CommonProxy.java
+++ b/src/main/java/jiraiyah/villageinfo/proxies/CommonProxy.java
@@ -20,6 +20,7 @@ package jiraiyah.villageinfo.proxies;
 import jiraiyah.villageinfo.inits.CommonEventRegister;
 import jiraiyah.villageinfo.inits.NetworkMessages;
 import jiraiyah.villageinfo.interfaces.IProxy;
+import jiraiyah.villageinfo.utilities.Log;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -36,6 +37,7 @@ public class CommonProxy implements IProxy
 	@Override
 	public void init(FMLInitializationEvent event)
 	{
+		//Log.info("=========================================================> Register NetworkMessages");
 		NetworkMessages.register();
 	}
 

--- a/src/main/java/jiraiyah/villageinfo/references/Reference.java
+++ b/src/main/java/jiraiyah/villageinfo/references/Reference.java
@@ -21,8 +21,9 @@ public class Reference
 {
 	public static final String MOD_ID = "villageinfo";
 	public static final String MOD_NAME = "Village Info";
-	public static final String VERSION = "@VERSION@";
-	public static final String DEPENDENCIES = "required-after:Forge@[12.16.0.1859,)";
+    public static final String VERSION = "@VERSION@";
+    public static final String FORGE = "${forgeversion}";
+    public static final String MINECRAFT = "${mcversion}";
 	public static final String CLIENT_PROXY = "jiraiyah.villageinfo.proxies.ClientProxy";
 	public static final String COMMON_PROXY = "jiraiyah.villageinfo.proxies.CommonProxy";
 }


### PR DESCRIPTION
- Changed the way the UUID was read and writen to the buffer of the iMessage packet
- Disabled all the features except for VillageInfo
- Added some commented log lines for debuging

It's not pretty, but it works. You can find the VillageInfo text at the center of the village.